### PR TITLE
Fix title in work history page

### DIFF
--- a/projects/work-history.html
+++ b/projects/work-history.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="generator" content="pandoc" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-    <title>work History</title>
+    <title>Work History</title>
     <link rel="stylesheet" href="../awsm_theme_big-stone.css">
     <link rel="stylesheet" href="../custom.css">
     <!--[if lt IE 9]>


### PR DESCRIPTION
Capitalise the `w` in `work` in the title element of the work history
page.